### PR TITLE
Notify deployer after locking for 2hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Self-signed certificates won't work for Slack, [Letsencrypt](https://letsencrypt
 Now compile and run the server (assuming that you have `go` installed):
 
 ```
-go get github.com/andrewslotin/michael
+go get github.com/adjust/michaelbot
 SLACK_TOKEN=<token you copied before> $GOPATH/bin/michael
 ```
 
@@ -116,10 +116,10 @@ To see the history of deploys in channel run <kbd>/deploy history</kbd> in this 
 This will open a page in your browser with all deploys that were ever announced in this channel.
 
 ```
-* suddendef was deploying https://github.com/andrewslotin/michael/pull/15 since 24 Aug 16 20:54 UTC until 24 Aug 16 20:54 UTC
-* suddendef was deploying https://github.com/andrewslotin/michael/pull/15 https://github.com/andrewslotin/michael/pull/11 since 24 Aug 16 20:54 UTC until 24 Aug 16 20:55 UTC
+* suddendef was deploying https://github.com/adjust/michaelbot/pull/15 since 24 Aug 16 20:54 UTC until 24 Aug 16 20:54 UTC
+* suddendef was deploying https://github.com/adjust/michaelbot/pull/15 https://github.com/adjust/michaelbot/pull/11 since 24 Aug 16 20:54 UTC until 24 Aug 16 20:55 UTC
 * suddendef was deploying history since 25 Aug 16 08:35 UTC until 25 Aug 16 08:35 UTC
-* suddendef was deploying https://github.com/andrewslotin/michael/pull/19 since 25 Aug 16 08:35 UTC until 25 Aug 16 08:35 UTC
+* suddendef was deploying https://github.com/adjust/michaelbot/pull/19 since 25 Aug 16 08:35 UTC until 25 Aug 16 08:35 UTC
 ```
 
 #### Authorization and authentication

--- a/auth/channel_access_token_test.go
+++ b/auth/channel_access_token_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/auth"
+	"github.com/adjust/michaelbot/auth"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/auth/channel_authorizer.go
+++ b/auth/channel_authorizer.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/andrewslotin/michael/dashboard"
+	"github.com/adjust/michaelbot/dashboard"
 )
 
 type ChannelAuthorizer struct {

--- a/auth/channel_authorizer_test.go
+++ b/auth/channel_authorizer_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/auth"
-	"github.com/andrewslotin/michael/auth/authtest"
+	"github.com/adjust/michaelbot/auth"
+	"github.com/adjust/michaelbot/auth/authtest"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/auth/one_time_token_authenticator_test.go
+++ b/auth/one_time_token_authenticator_test.go
@@ -3,8 +3,8 @@ package auth_test
 import (
 	"testing"
 
-	"github.com/andrewslotin/michael/auth"
-	"github.com/andrewslotin/michael/auth/authtest"
+	"github.com/adjust/michaelbot/auth"
+	"github.com/adjust/michaelbot/auth/authtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/auth/random_token_source_test.go
+++ b/auth/random_token_source_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/auth"
+	"github.com/adjust/michaelbot/auth"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/auth/token_authenticator.go
+++ b/auth/token_authenticator.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/andrewslotin/michael/dashboard"
+	"github.com/adjust/michaelbot/dashboard"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 

--- a/auth/token_authenticator_test.go
+++ b/auth/token_authenticator_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/auth"
-	"github.com/andrewslotin/michael/auth/authtest"
+	"github.com/adjust/michaelbot/auth"
+	"github.com/adjust/michaelbot/auth/authtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/andrewslotin/michael/auth"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/github"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/auth"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/github"
+	"github.com/adjust/michaelbot/slack"
 )
 
 type DeployEventHandler interface {

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/github"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/github"
+	"github.com/adjust/michaelbot/slack"
 )
 
 const (

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/bot"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/github"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/bot"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/github"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bot/slack_im_notifier.go
+++ b/bot/slack_im_notifier.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 )
 
 type SlackIMNotifier struct {

--- a/bot/slack_im_notifier.go
+++ b/bot/slack_im_notifier.go
@@ -3,26 +3,52 @@ package bot
 import (
 	"fmt"
 	"log"
+	"sync"
+	"time"
 
 	"github.com/adjust/michaelbot/deploy"
 	"github.com/adjust/michaelbot/slack"
 )
 
 type SlackIMNotifier struct {
-	im    *slack.InstantMessenger
-	users *slack.TeamDirectory
+	im             *slack.InstantMessenger
+	users          *slack.TeamDirectory
+	warningTimeout time.Duration
+	timer          *time.Timer
+	mutex          sync.Mutex
 }
 
-func NewSlackIMNotifier(api *slack.WebAPI) *SlackIMNotifier {
+func NewSlackIMNotifier(api *slack.WebAPI, warningTimeout time.Duration) *SlackIMNotifier {
 	return &SlackIMNotifier{
-		im:    slack.NewInstantMessenger(api),
-		users: slack.NewTeamDirectory(api),
+		im:             slack.NewInstantMessenger(api),
+		users:          slack.NewTeamDirectory(api),
+		warningTimeout: warningTimeout,
 	}
 }
 
-func (notifier *SlackIMNotifier) DeployStarted(_ string, _ deploy.Deploy) {}
+func (notifier *SlackIMNotifier) DeployStarted(_ string, d deploy.Deploy) {
+	notifier.mutex.Lock()
+	defer notifier.mutex.Unlock()
+
+	notifier.timer = time.AfterFunc(notifier.warningTimeout, func() {
+		message := slack.Message{
+			Text: fmt.Sprintf("Your deploy %q was started %s ago. Are you still deploying?", d.Subject, notifier.warningTimeout),
+		}
+
+		err := notifier.im.SendMessage(d.User, message)
+		if err != nil {
+			log.Printf("failed to send an instant message to %s: %s", d.User.Name, err)
+		}
+	})
+}
 
 func (notifier *SlackIMNotifier) DeployCompleted(_ string, d deploy.Deploy) {
+	notifier.mutex.Lock()
+	if notifier.timer != nil {
+		notifier.timer.Stop()
+	}
+	notifier.mutex.Unlock()
+
 	var (
 		user slack.User
 		err  error
@@ -54,4 +80,10 @@ func (notifier *SlackIMNotifier) DeployCompleted(_ string, d deploy.Deploy) {
 	}
 }
 
-func (notifier *SlackIMNotifier) DeployAborted(_ string, _ deploy.Deploy) {}
+func (notifier *SlackIMNotifier) DeployAborted(_ string, _ deploy.Deploy) {
+	notifier.mutex.Lock()
+	if notifier.timer != nil {
+		notifier.timer.Stop()
+	}
+	notifier.mutex.Unlock()
+}

--- a/bot/slack_im_notifier_test.go
+++ b/bot/slack_im_notifier_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/andrewslotin/michael/bot"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/bot"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bot/slack_topic_manager.go
+++ b/bot/slack_topic_manager.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 )
 
 const (

--- a/bot/slack_topic_manager_test.go
+++ b/bot/slack_topic_manager_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/andrewslotin/michael/bot"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/bot"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andrewslotin/michael/dashboard/formatters"
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/dashboard/formatters"
+	"github.com/adjust/michaelbot/deploy"
 )
 
 type Dashboard struct {

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/dashboard"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/dashboard"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/dashboard/formatters/json.go
+++ b/dashboard/formatters/json.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 )
 
 var (

--- a/dashboard/formatters/plain_text.go
+++ b/dashboard/formatters/plain_text.go
@@ -6,7 +6,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 )
 
 var (

--- a/dashboard/formatters/response_formatter.go
+++ b/dashboard/formatters/response_formatter.go
@@ -3,7 +3,7 @@ package formatters
 import (
 	"net/http"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 )
 
 type ResponseFormatter interface {

--- a/deploy/bolt_db_store.go
+++ b/deploy/bolt_db_store.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/boltdb/bolt"
 )
 

--- a/deploy/bolt_db_store_test.go
+++ b/deploy/bolt_db_store_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/deploy/channel_deploys_test.go
+++ b/deploy/channel_deploys_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -3,7 +3,7 @@ package deploy
 import (
 	"time"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 )
 
 type Deploy struct {

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/deploy/in_memory_store_test.go
+++ b/deploy/in_memory_store_test.go
@@ -3,7 +3,7 @@ package deploy_test
 import (
 	"testing"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/deploy/references_test.go
+++ b/deploy/references_test.go
@@ -3,7 +3,7 @@ package deploy_test
 import (
 	"testing"
 
-	"github.com/andrewslotin/michael/deploy"
+	"github.com/adjust/michaelbot/deploy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/deploy/repository_test.go
+++ b/deploy/repository_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/deploy/store_test.go
+++ b/deploy/store_test.go
@@ -3,8 +3,8 @@ package deploy_test
 import (
 	"time"
 
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/andrewslotin/michael/github"
+	"github.com/adjust/michaelbot/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 		// Update channel topic to reflect current deploy status
 		slackBot.AddDeployEventHandler(bot.NewSlackTopicManager(api))
 		// Send direct messages to users mentioned in deploy subject
-		slackBot.AddDeployEventHandler(bot.NewSlackIMNotifier(api))
+		slackBot.AddDeployEventHandler(bot.NewSlackIMNotifier(api, 2*time.Hour))
 	} else {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}

--- a/main.go
+++ b/main.go
@@ -11,12 +11,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/andrewslotin/michael/auth"
-	"github.com/andrewslotin/michael/bot"
-	"github.com/andrewslotin/michael/dashboard"
-	"github.com/andrewslotin/michael/deploy"
-	"github.com/andrewslotin/michael/server"
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/auth"
+	"github.com/adjust/michaelbot/bot"
+	"github.com/adjust/michaelbot/dashboard"
+	"github.com/adjust/michaelbot/deploy"
+	"github.com/adjust/michaelbot/server"
+	"github.com/adjust/michaelbot/slack"
 )
 
 const (
@@ -52,7 +52,7 @@ func init() {
 func printVersion() {
 	fmt.Printf("%s v%s (rev %s)\n", binPath, version, buildRev)
 	fmt.Printf("Built with %s on %s by %s\n\n", buildGoVersion, buildDate, builder)
-	fmt.Println("Found a bug? Got an idea? Open an issue on https://github.com/andrewslotin/michael\nContributions are welcome!")
+	fmt.Println("Found a bug? Got an idea? Open an issue on https://github.com/adjust/michaelbot\nContributions are welcome!")
 	os.Exit(0)
 }
 

--- a/slack/attachment_test.go
+++ b/slack/attachment_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/slack/instant_messenger_test.go
+++ b/slack/instant_messenger_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/slack/response_test.go
+++ b/slack/response_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/slack/response_type_test.go
+++ b/slack/response_type_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/slack/team_directory_test.go
+++ b/slack/team_directory_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/slack/user_test.go
+++ b/slack/user_test.go
@@ -3,7 +3,7 @@ package slack_test
 import (
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/slack/util_test.go
+++ b/slack/util_test.go
@@ -3,7 +3,7 @@ package slack_test
 import (
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/slack/webapi_test.go
+++ b/slack/webapi_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/andrewslotin/michael/slack"
+	"github.com/adjust/michaelbot/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -46,5 +46,5 @@
 			"revisionTime": "2016-04-18T22:58:27Z"
 		}
 	],
-	"rootPath": "github.com/andrewslotin/michael"
+	"rootPath": "github.com/adjust/michaelbot"
 }


### PR DESCRIPTION
this is a time based warning. 

potentially we can make it better:
have a go routine keep checking the status of the PR and once it's merged and the lock is not released for 10min, ping the owner.