### PR TITLE
Add deploy queue

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -136,6 +136,10 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else if errors.Is(err, deploy.AlreadyInQueueError) {
 			sendImmediateResponse(w, b.responses.UserIsInQeueueMessage(d.User))
 			return
+		} else if err != nil {
+			log.Printf("failed to start a deploy: (%s)", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
 		}
 
 		w.Write(nil)

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -22,8 +22,10 @@ const (
 /deploy history — get a link to history of deploys in this channel`
 	errorMessage                   = "`%s` returned an error %s"
 	noRunningDeploysMessage        = "No one is deploying at the moment"
-	deployStatusMessage            = "%s is deploying %s since %s"
-	deployConflictMessage          = "%s is deploying since %s. You can type `/deploy done` if you think this deploy is finished."
+	singleDeployStatusMessage      = "%s is deploying %s since %s. There are no other deploys scheduled yet."
+	deployQueueStatusMessage       = "%s is deploying %s since %s. The queue is %s."
+	alreadyInQueueMessage          = "%s is already in queue"
+	deployConflictMessage          = "%s is deploying since %s, your PR has been added to the queue. You can type `/deploy done` if you think the current deploy is finished or type `/deploy status` to print the queue."
 	deployDoneMessage              = "%s done deploying"
 	deployInterruptedMessage       = "%s has finished the deploy started by %s"
 	deployAnnouncementMessage      = "%s is about to deploy %s"
@@ -52,12 +54,32 @@ func (b *ResponseBuilder) NoRunningDeploysMessage() *slack.Response {
 	return newUserMessage(slack.EscapeMessage(noRunningDeploysMessage))
 }
 
-func (b *ResponseBuilder) DeployStatusMessage(d deploy.Deploy) *slack.Response {
-	return newUserMessage(fmt.Sprintf(deployStatusMessage, d.User, slack.EscapeMessage(d.Subject), d.StartedAt.Format(time.RFC822)))
+func (b *ResponseBuilder) DeployStatusMessage(deploys []deploy.Deploy) *slack.Response {
+	if len(deploys) == 1 {
+		d := deploys[0]
+
+		return newUserMessage(fmt.Sprintf(singleDeployStatusMessage, d.User, slack.EscapeMessage(d.Subject), d.StartedAt.Format(time.RFC822)))
+	} else {
+		current := deploys[0]
+		rest := deploys[1:]
+		users := make([]string, len(rest))
+
+		for i, d := range rest {
+			users[i] = fmt.Sprintf("%d. %s", i+1, d.User)
+		}
+
+		return newUserMessage(
+			fmt.Sprintf(deployQueueStatusMessage, current.User, slack.EscapeMessage(current.Subject), current.StartedAt.Format(time.RFC822), strings.Join(users, ", ")),
+		)
+	}
 }
 
 func (b *ResponseBuilder) DeployInProgressMessage(d deploy.Deploy) *slack.Response {
 	return newUserMessage(fmt.Sprintf(deployConflictMessage, d.User, d.StartedAt.Format(time.RFC822)))
+}
+
+func (b *ResponseBuilder) UserIsInQeueueMessage(u slack.User) *slack.Response {
+	return newUserMessage(fmt.Sprintf(alreadyInQueueMessage, u))
 }
 
 func (b *ResponseBuilder) DeployInterruptedAnnouncement(d deploy.Deploy, user slack.User) *slack.Response {

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -29,7 +29,7 @@ const (
 	deployDoneMessage              = "%s done deploying"
 	deployInterruptedMessage       = "%s has finished the deploy started by %s"
 	deployAnnouncementMessage      = "%s is about to deploy %s"
-	deployHistoryLinkMessage       = "Click <https://%s/%s|here> to see deploy history in this channel"
+	deployHistoryLinkMessage       = "Click <http://%s/%s|here> to see deploy history in this channel"
 	deployAbortedMessage           = "%s has aborted the deploy"
 	deployAbortedWithReasonMessage = "%s has aborted the deploy (%s)"
 	userLeftQueueMessage           = "Your scheduled deploy has been cancelled"

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -47,9 +47,10 @@ func TestResponseBuilder_DeployStatusMessage(t *testing.T) {
 		Subject:   "deploy subject",
 		StartedAt: time.Now(),
 	}
+	ds := []deploy.Deploy{d}
 
 	b := bot.NewResponseBuilder(github.NewClient("", nil))
-	response := b.DeployStatusMessage(d)
+	response := b.DeployStatusMessage(ds)
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
 	assert.Contains(t, response.Text, d.User.String())

--- a/bot/slack_im_notifier_test.go
+++ b/bot/slack_im_notifier_test.go
@@ -41,11 +41,11 @@ func TestSlackIMNotifier_DeployCompleted(t *testing.T) {
 
 		fmt.Fprint(w, `{"ok":true,"members":[{"id":"R1","name":"recipient1"},{"id":"R2","name":"recipient2"},{"id":"R3","name":"recipient3"}]}`)
 	})
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		requestNum.IMOpen++
 		assert.Equal(t, webAPIToken, r.FormValue("token"))
 
-		if userID := r.FormValue("user"); assert.NotEmpty(t, userID) {
+		if userID := r.FormValue("users"); assert.NotEmpty(t, userID) {
 			fmt.Fprintf(w, `{"ok":true,"channel":{"id":"DM%s"}}`, userID)
 		} else {
 			fmt.Fprint(w, `{"ok":false,"error":"user_not_found"}`)
@@ -109,11 +109,11 @@ func TestSlackIMNotifier_DeployStart_Warning(t *testing.T) {
 		receivers  []string
 	)
 
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		requestNum.IMOpen++
 		assert.Equal(t, webAPIToken, r.FormValue("token"))
 
-		if userID := r.FormValue("user"); assert.NotEmpty(t, userID) {
+		if userID := r.FormValue("users"); assert.NotEmpty(t, userID) {
 			fmt.Fprintf(w, `{"ok":true,"channel":{"id":"DM%s"}}`, userID)
 		} else {
 			fmt.Fprint(w, `{"ok":false,"error":"user_not_found"}`)
@@ -168,7 +168,7 @@ func TestSlackIMNotifier_DeployStart_CompletedBeforeWarning(t *testing.T) {
 		requestNum struct{ IMPostMessage, IMOpen int }
 	)
 
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		requestNum.IMOpen++
 		fmt.Println(r)
 	})
@@ -205,7 +205,7 @@ func TestSlackIMNotifier_DeployStart_AbortBeforeWarning(t *testing.T) {
 		requestNum struct{ IMPostMessage, IMOpen int }
 	)
 
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		requestNum.IMOpen++
 		fmt.Println(r)
 	})

--- a/deploy/bolt_db_store.go
+++ b/deploy/bolt_db_store.go
@@ -82,7 +82,11 @@ func (s *BoltDBStore) SetQueue(key string, queue Queue) {
 			return fmt.Errorf("failed to marshal queue %#v: %s", queue, err)
 		}
 
-		bucket.Put([]byte("queue"), bytes)
+		err = bucket.Put([]byte("queue"), bytes)
+
+		if err != nil {
+			return fmt.Errorf("failed to put queue into a bucket %#v: %s", queue, err)
+		}
 
 		return nil
 	})
@@ -110,7 +114,11 @@ func (s *BoltDBStore) AddToHistory(key string, deploy Deploy) {
 
 		id, _ := bucket.NextSequence()
 
-		bucket.Put(itob(id), bytes)
+		err = bucket.Put(itob(id), bytes)
+
+		if err != nil {
+			return fmt.Errorf("failed to put deploy into a bucket %#v: %s", deploy, err)
+		}
 
 		return nil
 	})

--- a/deploy/bolt_db_store.go
+++ b/deploy/bolt_db_store.go
@@ -112,6 +112,8 @@ func (s *BoltDBStore) AddToHistory(key string, deploy Deploy) {
 			return fmt.Errorf("failed to marshal deploy %#v: %s", deploy, err)
 		}
 
+		// This returns an error only if the Tx is closed or not writeable.
+		// That can't happen in an Update() call so we can ignore the error check.
 		id, _ := bucket.NextSequence()
 
 		err = bucket.Put(itob(id), bytes)

--- a/deploy/bolt_db_store_test.go
+++ b/deploy/bolt_db_store_test.go
@@ -41,7 +41,7 @@ func TestBoltDBStore_AsRepository(t *testing.T) {
 			return nil, nil, teardownFn, err
 		}
 
-		return r, r.Set, teardownFn, nil
+		return r, r.AddToHistory, teardownFn, nil
 	}})
 }
 

--- a/deploy/channel_deploys.go
+++ b/deploy/channel_deploys.go
@@ -1,5 +1,14 @@
 package deploy
 
+import (
+	"errors"
+)
+
+var (
+	AlreadyInQueueError   = errors.New("User is already in queue")
+	DeployInProgressError = errors.New("Another deploy is in progress")
+)
+
 type ChannelDeploys struct {
 	store Store
 }
@@ -8,51 +17,75 @@ func NewChannelDeploys(store Store) *ChannelDeploys {
 	return &ChannelDeploys{store: store}
 }
 
-func (repo *ChannelDeploys) Current(channelID string) (Deploy, bool) {
-	d, ok := repo.store.Get(channelID)
-	return d, ok && d.FinishedAt.IsZero()
+func (repo *ChannelDeploys) All(channelID string) []Deploy {
+	queue := repo.store.GetQueue(channelID)
+
+	return queue.Items
 }
 
-func (repo *ChannelDeploys) Start(channelID string, d Deploy) (Deploy, bool) {
-	for {
-		current, ok := repo.Current(channelID)
-		if !ok {
-			break
-		}
+func (repo *ChannelDeploys) Current(channelID string) (Deploy, bool) {
+	queue := repo.store.GetQueue(channelID)
 
-		if current.User.ID != d.User.ID {
-			return current, false
-		}
+	return queue.Current()
+}
 
-		repo.Finish(channelID)
+func (repo *ChannelDeploys) Start(channelID string, deploy Deploy) (Deploy, error) {
+	queue := repo.store.GetQueue(channelID)
+
+	current, deployInProgress := queue.Current()
+
+	if queue.IsUserInQueue(deploy.User) {
+		return deploy, AlreadyInQueueError
 	}
 
-	d.Start()
-	repo.store.Set(channelID, d)
+	if deployInProgress {
+		queue.Add(deploy)
+		repo.store.SetQueue(channelID, queue)
 
-	return d, true
+		return current, DeployInProgressError
+	}
+
+	deploy.Start()
+	queue.Add(deploy)
+	repo.store.SetQueue(channelID, queue)
+
+	return deploy, nil
 }
 
 func (repo *ChannelDeploys) Finish(channelID string) (Deploy, bool) {
-	current, ok := repo.Current(channelID)
-	if !ok {
+	queue := repo.store.GetQueue(channelID)
+	current, deployInProgress := queue.Pop()
+
+	if !deployInProgress {
 		return current, false
 	}
 
 	current.Finish()
-	repo.store.Set(channelID, current)
+	repo.store.AddToHistory(channelID, current)
+	repo.store.SetQueue(channelID, queue)
 
 	return current, true
 }
 
 func (repo *ChannelDeploys) Abort(channelID, reason string) (Deploy, bool) {
-	current, ok := repo.Current(channelID)
-	if !ok {
+	queue := repo.store.GetQueue(channelID)
+	current, deployInProgress := queue.Pop()
+
+	if !deployInProgress {
 		return current, false
 	}
 
 	current.Abort(reason)
-	repo.store.Set(channelID, current)
+	repo.store.AddToHistory(channelID, current)
+
+	next, queueIsNotEmpty := queue.Current()
+
+	if queueIsNotEmpty {
+		next.Start()
+		queue.ReplaceHeadWith(next)
+	}
+
+	repo.store.SetQueue(channelID, queue)
 
 	return current, true
 }

--- a/deploy/channel_deploys.go
+++ b/deploy/channel_deploys.go
@@ -2,6 +2,8 @@ package deploy
 
 import (
 	"errors"
+
+	"github.com/adjust/michaelbot/slack"
 )
 
 var (
@@ -88,4 +90,16 @@ func (repo *ChannelDeploys) Abort(channelID, reason string) (Deploy, bool) {
 	repo.store.SetQueue(channelID, queue)
 
 	return current, true
+}
+
+func (repo *ChannelDeploys) LeaveQueue(channelID string, user slack.User) bool {
+	queue := repo.store.GetQueue(channelID)
+
+	userHasBeenRemoved := queue.RemoveUser(user)
+
+	if userHasBeenRemoved {
+		repo.store.SetQueue(channelID, queue)
+	}
+
+	return userHasBeenRemoved
 }

--- a/deploy/channel_deploys.go
+++ b/deploy/channel_deploys.go
@@ -64,6 +64,14 @@ func (repo *ChannelDeploys) Finish(channelID string) (Deploy, bool) {
 
 	current.Finish()
 	repo.store.AddToHistory(channelID, current)
+
+	next, queueIsNotEmpty := queue.Current()
+
+	if queueIsNotEmpty {
+		next.Start()
+		queue.ReplaceHeadWith(next)
+	}
+
 	repo.store.SetQueue(channelID, queue)
 
 	return current, true

--- a/deploy/channel_deploys_test.go
+++ b/deploy/channel_deploys_test.go
@@ -17,19 +17,16 @@ type StoreMock struct {
 	mock.Mock
 }
 
-func (m *StoreMock) Get(key string) (deploy.Deploy, bool) {
+func (m *StoreMock) GetQueue(key string) deploy.Queue {
 	args := m.Called(key)
-	return args.Get(0).(deploy.Deploy), args.Bool(1)
+	return args.Get(0).(deploy.Queue)
 }
 
-func (m *StoreMock) Set(key string, d deploy.Deploy) {
-	m.Called(key, d)
+func (m *StoreMock) SetQueue(key string, q deploy.Queue) {
+	m.Called(key, q)
 }
 
-func (m *StoreMock) Del(key string) (d deploy.Deploy, ok bool) {
-	args := m.Called(key)
-	return args.Get(0).(deploy.Deploy), args.Bool(1)
-}
+func (m *StoreMock) AddToHistory(key string, d deploy.Deploy) {}
 
 /*
    Tests
@@ -39,10 +36,13 @@ func TestChannelDeploys_Current(t *testing.T) {
 	current := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
 	current.StartedAt = time.Now().Add(-5 * time.Minute)
 
+	queue := deploy.NewEmptyQueue()
+	queue.Add(current)
+
 	store := new(StoreMock)
 	store.
-		On("Get", "key1").Return(current, true).
-		On("Get", "key2").Return(deploy.Deploy{}, false)
+		On("GetQueue", "key1").Return(queue, true).
+		On("GetQueue", "key2").Return(deploy.NewEmptyQueue(), false)
 
 	repo := deploy.NewChannelDeploys(store)
 
@@ -56,66 +56,18 @@ func TestChannelDeploys_Current(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-func TestChannelDeploys_Start(t *testing.T) {
-	current := deploy.New(slack.User{ID: "2", Name: "Another User"}, "Active deploy")
-	current.StartedAt = time.Now().Add(-2 * time.Minute)
-
-	store := new(StoreMock)
-	store.
-		On("Get", "key1").Return(deploy.Deploy{}, false).
-		On("Get", "key2").Return(current, true)
-	store.
-		On("Set", "key1", mock.AnythingOfType("deploy.Deploy")).Return()
-
-	repo := deploy.NewChannelDeploys(store)
-
-	d := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
-	if started, ok := repo.Start("key1", d); assert.True(t, ok) {
-		assert.Equal(t, d.User, started.User)
-		assert.Equal(t, d.Subject, started.Subject)
-		assert.WithinDuration(t, time.Now(), started.StartedAt, time.Second)
-	}
-
-	d = deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
-	if started, ok := repo.Start("key2", d); assert.False(t, ok) {
-		assert.Equal(t, current, started)
-	}
-
-	store.AssertExpectations(t)
-}
-
-func TestChannelDeploys_Start_UpdateCurrent(t *testing.T) {
-	current := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Active deploy")
-	current.StartedAt = time.Now().Add(-2 * time.Minute)
-
-	store := new(StoreMock)
-	store.
-		On("Get", "key1").Return(current, true).Once(). // return running deploy
-		On("Set", "key1", mock.AnythingOfType("deploy.Deploy")).Return(current, true).Once().
-		On("Get", "key1").Return(deploy.Deploy{}, false). // current deploy has already been finished
-		On("Set", "key1", mock.AnythingOfType("deploy.Deploy")).Return()
-
-	repo := deploy.NewChannelDeploys(store)
-
-	d := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
-	if started, ok := repo.Start("key1", d); assert.True(t, ok) {
-		assert.Equal(t, d.User, started.User)
-		assert.Equal(t, d.Subject, started.Subject)
-		assert.WithinDuration(t, time.Now(), started.StartedAt, time.Second)
-	}
-
-	store.AssertExpectations(t)
-}
-
 func TestChannelDeploys_Finish(t *testing.T) {
 	current := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
 	current.StartedAt = time.Now().Add(-2 * time.Second)
 
+	queue := deploy.NewEmptyQueue()
+	queue.Add(current)
+
 	store := new(StoreMock)
 	store.
-		On("Get", "key1").Return(current, true).
-		On("Get", "key2").Return(deploy.Deploy{}, false).
-		On("Set", "key1", mock.AnythingOfType("deploy.Deploy")).Return()
+		On("GetQueue", "key1").Return(queue, true).
+		On("GetQueue", "key2").Return(deploy.NewEmptyQueue(), false).
+		On("SetQueue", "key1", mock.AnythingOfType("deploy.Queue")).Return()
 
 	repo := deploy.NewChannelDeploys(store)
 
@@ -134,11 +86,14 @@ func TestChannelDeploys_Abort(t *testing.T) {
 	current := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test subject")
 	current.StartedAt = time.Now().Add(-2 * time.Second)
 
+	queue := deploy.NewEmptyQueue()
+	queue.Add(current)
+
 	store := new(StoreMock)
 	store.
-		On("Get", "key1").Return(current, true).
-		On("Get", "key2").Return(deploy.Deploy{}, false).
-		On("Set", "key1", mock.AnythingOfType("deploy.Deploy")).Return()
+		On("GetQueue", "key1").Return(queue, true).
+		On("GetQueue", "key2").Return(deploy.NewEmptyQueue(), false).
+		On("SetQueue", "key1", mock.AnythingOfType("deploy.Queue")).Return()
 
 	repo := deploy.NewChannelDeploys(store)
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -49,6 +49,24 @@ func (q *Queue) IsUserInQueue(u slack.User) bool {
 	return false
 }
 
+func (q *Queue) RemoveUser(u slack.User) bool {
+	if !q.IsUserInQueue(u) {
+		return false
+	}
+
+	filtered := make([]Deploy, 0)
+
+	for _, d := range q.Items {
+		if d.User.ID != u.ID {
+			filtered = append(filtered, d)
+		}
+	}
+
+	q.Items = filtered
+
+	return true
+}
+
 func (q *Queue) ReplaceHeadWith(d Deploy) {
 	q.Items[0] = d
 }

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -6,6 +6,53 @@ import (
 	"github.com/adjust/michaelbot/slack"
 )
 
+type Queue struct {
+	Items []Deploy
+}
+
+func NewEmptyQueue() Queue {
+	return Queue{make([]Deploy, 0)}
+}
+
+func (q *Queue) Add(d Deploy) {
+	q.Items = append(q.Items, d)
+}
+
+func (q *Queue) Current() (d Deploy, ok bool) {
+	if len(q.Items) > 0 {
+		return q.Items[0], true
+	} else {
+		return Deploy{}, false
+	}
+}
+
+func (q *Queue) Pop() (d Deploy, ok bool) {
+	if len(q.Items) > 0 {
+		ok = true
+		d = q.Items[0]
+		q.Items = q.Items[1:len(q.Items)]
+	} else {
+		ok = false
+		d = Deploy{}
+	}
+
+	return d, ok
+}
+
+func (q *Queue) IsUserInQueue(u slack.User) bool {
+	for _, d := range q.Items {
+		if d.User.ID == u.ID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (q *Queue) ReplaceHeadWith(d Deploy) {
+	q.Items[0] = d
+}
+
 type Deploy struct {
 	User         slack.User
 	Subject      string

--- a/deploy/in_memory_store_test.go
+++ b/deploy/in_memory_store_test.go
@@ -16,6 +16,6 @@ func TestInMemoryStore_AsStore(t *testing.T) {
 func TestInMemoryStore_AsRepository(t *testing.T) {
 	suite.Run(t, &RepositorySuite{Setup: func() (repo deploy.Repository, setFn func(string, deploy.Deploy), teardownFn func(), err error) {
 		r := deploy.NewInMemoryStore()
-		return r, r.Set, nil, nil
+		return r, r.AddToHistory, nil, nil
 	}})
 }

--- a/deploy/store.go
+++ b/deploy/store.go
@@ -1,6 +1,7 @@
 package deploy
 
 type Store interface {
-	Get(key string) (d Deploy, ok bool)
-	Set(key string, d Deploy)
+	GetQueue(key string) Queue
+	SetQueue(key string, q Queue)
+	AddToHistory(key string, d Deploy)
 }

--- a/slack/webapi.go
+++ b/slack/webapi.go
@@ -121,10 +121,10 @@ func (api *WebAPI) PostMessage(channelID string, message Message) error {
 }
 
 func (api *WebAPI) OpenIMChannel(user User) (string, error) {
-	const method = "im.open"
+	const method = "conversations.open"
 
 	params := url.Values{}
-	params.Set("user", user.ID)
+	params.Set("users", user.ID)
 
 	resp, requestURL, err := api.Call(method, params)
 	if err != nil {

--- a/slack/webapi_test.go
+++ b/slack/webapi_test.go
@@ -315,9 +315,9 @@ func TestWebAPI_OpenIMChannel(t *testing.T) {
 	user := slack.User{ID: "123", Name: "user1"}
 
 	var requestNum int
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "xxxx-token-12345", r.FormValue("token"))
-		assert.Equal(t, user.ID, r.FormValue("user"))
+		assert.Equal(t, user.ID, r.FormValue("users"))
 
 		requestNum++
 		w.Write([]byte(`{"ok":true,"channel":{"id":"channel1"}}`))
@@ -340,9 +340,9 @@ func TestWebAPI_OpenIMChannel_ErrorHandling(t *testing.T) {
 	user := slack.User{ID: "123", Name: "user1"}
 
 	var requestNum int
-	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/conversations.open", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "xxxx-token-12345", r.FormValue("token"))
-		assert.Equal(t, user.ID, r.FormValue("user"))
+		assert.Equal(t, user.ID, r.FormValue("users"))
 
 		requestNum++
 		w.Write([]byte(`{"ok":false,"error":"user_not_found"`))


### PR DESCRIPTION
This commit introduces a queuing mechanism for the deploy command. It makes `/deploy start` command to put people in a queue, `/deploy abort` and `/deploy done` to remove an active deploy and start the next queued one, and `/deploy status` to show the current state of the queue. 