### PR TITLE
Fix deploy bot pinging the wrong person

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   run-unit-tests:
     name: run-unit-tests
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 michael
+.idea

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -104,6 +104,10 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		nextDeploy, nextDeployStarted := b.deploys.Current(channelID)
 		if nextDeployStarted {
 			go sendDelayedResponse(w, r, b.responses.DeployAnnouncement(nextDeploy))
+
+			for _, h := range b.deployEventHandlers {
+				go h.DeployStarted(channelID, d)
+			}
 		} else {
 			for _, h := range b.deployEventHandlers {
 				go h.DeployCompleted(channelID, d)

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -169,7 +169,7 @@ func TestResponseBuilder_DeployHistoryLink_WithAuthToken(t *testing.T) {
 	response := b.DeployHistoryLink("www.example.com:8080", "abc 123", "secret token")
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
-	assert.Contains(t, response.Text, "https://www.example.com:8080/abc%20123?token=secret+token")
+	assert.Contains(t, response.Text, "http://www.example.com:8080/abc%20123?token=secret+token")
 }
 
 func TestResponseBuilder_DeployHistoryLink_EmptyAuthToken(t *testing.T) {
@@ -177,7 +177,7 @@ func TestResponseBuilder_DeployHistoryLink_EmptyAuthToken(t *testing.T) {
 	response := b.DeployHistoryLink("www.example.com:8080", "abc 123", "")
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
-	assert.Contains(t, response.Text, "https://www.example.com:8080/abc%20123")
+	assert.Contains(t, response.Text, "http://www.example.com:8080/abc%20123")
 }
 
 func TestResponseBuilder_DeployHistoryLink_StandardPorts(t *testing.T) {
@@ -187,7 +187,7 @@ func TestResponseBuilder_DeployHistoryLink_StandardPorts(t *testing.T) {
 
 	for _, port := range standardPorts {
 		response := b.DeployHistoryLink("www.example.com:"+port, "abc 123", "")
-		assert.Contains(t, response.Text, "https://www.example.com/abc%20123", "port: %s", port)
+		assert.Contains(t, response.Text, "http://www.example.com/abc%20123", "port: %s", port)
 	}
 }
 

--- a/deploy/store_test.go
+++ b/deploy/store_test.go
@@ -26,8 +26,8 @@ func (suite *StoreSuite) TestGetSet() {
 	channelDeploy := deploy.Deploy{
 		User:        slack.User{ID: "1", Name: "Test User"},
 		Subject:     "Deploy subject a/b#1 and c/d#2 for @user1 and @user2",
-		StartedAt:   time.Now().Round(0).Add(-5 * time.Minute),
-		FinishedAt:  time.Now().Round(0).Add(-1 * time.Minute),
+		StartedAt:   time.Now().Round(0).Add(-5 * time.Minute).UTC(),
+		FinishedAt:  time.Now().Round(0).Add(-1 * time.Minute).UTC(),
 		Aborted:     true,
 		AbortReason: "something went wrong",
 		PullRequests: []deploy.PullRequestReference{


### PR DESCRIPTION
## The bug

1. Person 1 starts deployment
2. Person 2 gets in line
3. Person 1 finishes deployment faster than in 2 hours
4. Person 2 starts deploying and does it more than 2 hours
5. Person 1 receives a notification `"Your deploy %q was started %s ago. Are you still deploying?"` in Slack DM when 2h are passed since step 1. But notification should be sent to Person 2 when 2h passed since step 3.

## The cause

The old timer is not stopped and the new timer is not created when someone stops deploying and there are next person in the queue that starts deploying.

## The solution

We have two `deployEventHandlers` and we should call `DeployStarted()` on both of them when someone finishes deployment and next person in the queue starts deploying:

- `SlackIMNotifier::DeployStarted()` will reset the old timer (for previous person) and replace it with a new one (with next person)
- `SlackTopicManager::DeployStarted()` will do nothing (because new topic will be equal to the old one)


## Note

It would be nice to cover everything with unit tests, but extracting the business logic from `Bot::ServeHTTP()` method for now is not really practical, because this bot is not very critical to us.