### PR TITLE
Add documentation about using abort to leave queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Deploys are tracked per channel. This means that different channels can run diff
 
     <img src="../master/docs/deploy-abort-reason.png" alt="Deploy aborted with reason announcement" height="42">
 
+**Note: If you are currently waiting on the queue, you can use `abort` to remove yourself from it without impacting the current lock.**
+
 ### Deploy status in channel topic
 
 In addition to announcing deploys in channel you may find it useful to have a small sign in the channel topic. This way you can quickly check

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -18,7 +18,7 @@ const (
 /deploy <subject> — announce deploy of <subject> in channel
 /deploy status — show deploy status in channel
 /deploy done — finish deploy
-/deploy abort [<reason>] — abort current deploy, optionally providing a reason
+/deploy abort [<reason>] — abort current deploy, optionally providing a reason, or remove yourself from queue
 /deploy history — get a link to history of deploys in this channel`
 	errorMessage                   = "`%s` returned an error %s"
 	noRunningDeploysMessage        = "No one is deploying at the moment"


### PR DESCRIPTION
Adding doc about a case where we use `abort` to leave the queue.